### PR TITLE
組織 / プロジェクトの変更ごとに selected を空配列で初期化

### DIFF
--- a/vue-forgot-state-reset/src/App.vue
+++ b/vue-forgot-state-reset/src/App.vue
@@ -83,12 +83,16 @@ export default {
   },
   methods: {
     onSelectOrganization() {
+      this.selected = [];
+      this.members = [];
       if (this.organizationId === null) {
         this.projects = [];
       }
       this.projects = Projects.filter((p) => p.organizationId === this.organizationId);
     },
     onSelectProject() {
+      this.selected = [];
+      this.members = [];
       if (this.projectId === null) {
         this.members = [];
       }


### PR DESCRIPTION
また、企業を切り替える時にメンバー一覧が残ってしまうので、同タイミングで
members も空配列で初期化することで万が一の誤爆を防ぐ